### PR TITLE
Provide Indent combinator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ pomExtra := (
   </issueManagement>
 )
 
-lazy val benchmarks = project in file("benchmarks") dependsOn(root)
+lazy val benchmarks = project in file("benchmarks") aggregate (root)
 
 scalaVersion in benchmarks := "2.11.8"
 

--- a/src/main/scala/gnieh/pp/package.scala
+++ b/src/main/scala/gnieh/pp/package.scala
@@ -27,7 +27,7 @@ package object pp {
   def nest(indent: Int)(inner: Doc): Doc =
     NestDoc(indent, inner)
 
-  /* Deindent the document */
+  /** Deindent the document */
   @inline
   def unnest(indent: Int)(inner: Doc): Doc =
     nest(-indent)(inner)
@@ -184,30 +184,30 @@ package object pp {
     group(vcat(docs))
 
   @inline
-  implicit def s2doc(s: String) =
+  implicit def s2doc(s: String): Doc =
     string(s)
 
   @inline
-  implicit def i2doc(i: Int) =
+  implicit def i2doc(i: Int): Doc =
     int(i)
 
   @inline
-  implicit def l2doc(l: Long) =
+  implicit def l2doc(l: Long): Doc =
     long(l)
 
   @inline
-  implicit def f2doc(f: Float) =
+  implicit def f2doc(f: Float): Doc =
     float(f)
 
   @inline
-  implicit def d2doc(d: Double) =
+  implicit def d2doc(d: Double): Doc =
     double(d)
 
   @inline
-  implicit def c2doc(c: Char) =
+  implicit def c2doc(c: Char): Doc =
     char(c)
 
-  implicit def opt2doc[T <% Doc](o: Option[T]): Doc = o match {
+  implicit def opt2doc[T](o: Option[T])(implicit ev: T => Doc): Doc = o match {
     case Some(d) => d
     case None    => empty
   }

--- a/src/main/scala/gnieh/pp/package.scala
+++ b/src/main/scala/gnieh/pp/package.scala
@@ -66,6 +66,11 @@ package object pp {
   val empty: Doc =
     EmptyDoc
 
+  /** Renders the document with prepending n spaces to the current column */
+  @inline
+  def indent(i: Int)(doc: Doc): Doc =
+    hang(i)(ConsDoc(TextDoc(" " * i), doc))
+
   /** Renders the document with nesting level set to the current column */
   @inline
   def align(doc: Doc): Doc =

--- a/src/test/scala/gnieh/pp/tests/IndentTest.scala
+++ b/src/test/scala/gnieh/pp/tests/IndentTest.scala
@@ -1,0 +1,23 @@
+package gnieh.pp.tests
+
+import gnieh.pp._
+
+class IndentTest extends PpTest {
+  "the indent operator" should "indent text as block" in {
+    val docs: List[Doc] = List("line1", "line2", "line3")
+    val finalDoc = indent(2)(vcat(docs))
+
+    render80(finalDoc) should be("  line1\n  line2\n  line3")
+  }
+  it should "behave as original Haskell implementation" in {
+    val doc = indent(4)(fillSep(words("the indent combinator indents these words !")))
+
+    val expectedRender =
+      """    the indent
+        |    combinator
+        |    indents these
+        |    words !""".stripMargin
+
+    render20(doc) should be(expectedRender)
+  }
+}

--- a/src/test/scala/gnieh/pp/tests/ListCombinatorsTest.scala
+++ b/src/test/scala/gnieh/pp/tests/ListCombinatorsTest.scala
@@ -31,4 +31,11 @@ class ListCombinatorsTest extends PpTest {
     render80(test2) should be("some text\n     to\n     lay\n     out")
   }
 
+  "vcat" should "be indented when within an indentation block" in {
+    val docs: List[Doc] = List("line1", "line2", "line3")
+    val finalDoc = nest(2)(vcat(docs))
+
+    render80(finalDoc) should be("  line1\n  line2\n  line3")
+  }
+
 }

--- a/src/test/scala/gnieh/pp/tests/ListCombinatorsTest.scala
+++ b/src/test/scala/gnieh/pp/tests/ListCombinatorsTest.scala
@@ -30,12 +30,4 @@ class ListCombinatorsTest extends PpTest {
     val test2 = "some" :+: align(vsep(someText))
     render80(test2) should be("some text\n     to\n     lay\n     out")
   }
-
-  "vcat" should "be indented when within an indentation block" in {
-    val docs: List[Doc] = List("line1", "line2", "line3")
-    val finalDoc = nest(2)(vcat(docs))
-
-    render80(finalDoc) should be("  line1\n  line2\n  line3")
-  }
-
 }


### PR DESCRIPTION
Adds a new combinator replicating `indent` as in https://hackage.haskell.org/package/ansi-wl-pprint-0.6.7.3/docs/Text-PrettyPrint-ANSI-Leijen.html#v:indent.

Additionally add cosmetic issues and code annotations.