### PR TITLE
Exclude common prefix elements from common suffix

### DIFF
--- a/src/test/scala/gnieh/diff/TestLcs.scala
+++ b/src/test/scala/gnieh/diff/TestLcs.scala
@@ -103,4 +103,15 @@ abstract class TestLcs extends FlatSpec with Matchers {
 
   }
 
+  it should "not include overlapping prefix and suffix twice" in {
+
+    val str1 = "aabaa"
+    val str2 = "aaa"
+
+    val lcs = lcsImpl.lcs(str1, str2)
+
+    lcs should be(List(Common(0, 0, 2), Common(4, 2, 1)))
+
+  }
+
 }


### PR DESCRIPTION
If the element of one sequence participate to the common prefix, then we
must not take it into account when computing the remaining common
suffix. Otherwise, we have overlapping common elements in the Lcs.

fix #9