### PR TITLE
Add unit test to catch StackOverflowError in Patience alg

### DIFF
--- a/src/test/scala/gnieh/diff/TestLcs.scala
+++ b/src/test/scala/gnieh/diff/TestLcs.scala
@@ -114,4 +114,10 @@ abstract class TestLcs extends FlatSpec with Matchers {
 
   }
 
+  it should "not overflow stack for arrays" in {
+    val s1 = "abcdefghij"
+    val s2 = "adekfg"
+    lcsImpl.lcs(s1, s2) shouldBe List(Common(0, 0, 1), Common(3, 1, 2), Common(5, 4, 2))
+  }
+
 }


### PR DESCRIPTION
Please merge this test.

By the way, why don't you replace Patience algorithm (by default) with DynamicProgLcs, if it's so unreliable and inefficient? I thought before that dynamic programming could be slow on small datasets, but benchmarks say that performance is satisfactory (better than others two algorithms) for big and small datasets.

First suspect which can cause StackOverflowError - recursive `loop` method in Patience.scala:119 is not tail-recursive (which what exactly tailrec annotation says to us...). And personally I prefer to replace recursions and accumulator with foldLeft where possible. I will try do investigate what can be wrong and do something, but can't promise of course.