### PR TITLE
Make patience algorithm more stack friendly

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala/gnieh/diff/Patience.scala
+++ b/src/main/scala/gnieh/diff/Patience.scala
@@ -107,7 +107,7 @@ class Patience[T](withFallback: Boolean = true) extends Lcs[T] {
       // this call is safe as we know that the list of occurrence is not empty here and that there are no empty stacks
       val greatest = sorted.last.head
       // make the lcs in increasing order
-      greatest.chain.reverse
+      greatest.chain
     }
   }
 
@@ -181,11 +181,16 @@ class Patience[T](withFallback: Boolean = true) extends Lcs[T] {
   }
 
   private case class Stacked(idx1: Int, idx2: Int, next: Option[Stacked]) {
-    lazy val chain: List[Common] = next match {
-      case Some(stacked) =>
-        push(idx1, idx2, stacked.chain, false)
-      case None =>
-        List(Common(idx1, idx2, 1))
+    def chain: List[Common] = {
+      @tailrec
+      def loop(stacked: Stacked, acc: List[Common]): List[Common] =
+        stacked.next match {
+          case Some(next) =>
+            loop(next, push(stacked.idx1, stacked.idx2, acc, true))
+          case None =>
+            push(stacked.idx1, stacked.idx2, acc, true)
+        }
+      loop(this, Nil)
     }
   }
 


### PR DESCRIPTION
Inspired by the issue raised in diffson (see gnieh/diffson#63), turning
the `Stacked.chain` computation into a tail recursive method makes it
possible to use Patience algorithm on big arrays.